### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/turt2live/waffle-matrix.png?label=ready&title=Ready)](https://waffle.io/turt2live/waffle-matrix?utm_source=badge)
 # waffle-matrix
 
 Waffle board for Matrix bots/bridges: [turt2live/waffle-matrix](https://waffle.io/turt2live/waffle-matrix)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/turt2live/waffle-matrix

This was requested by a real person (user turt2live) on waffle.io, we're not trying to spam you.